### PR TITLE
[TASK] Add basic compatibility with QUnit 2

### DIFF
--- a/qunit-parameterize.js
+++ b/qunit-parameterize.js
@@ -11,7 +11,6 @@ QUnit.extend(QUnit, {
 		var createTest = function(methodName, title, expected, callback, parameters) {
 			QUnit[methodName](
 				title,
-				expected,
 				function(assert) { return callback.call(this, parameters, assert); }
 			);
 		};


### PR DESCRIPTION
The signature of the `test()` method changed, this "fixes" it by throwing out an argument. A real fix would probably need more changes, throwing out the `expected` value in more places.